### PR TITLE
add code enable reload mapper without class

### DIFF
--- a/src/main/java/com/github/wangji92/mybatis/reload/MybatisMapperXmlFileReloadProperties.java
+++ b/src/main/java/com/github/wangji92/mybatis/reload/MybatisMapperXmlFileReloadProperties.java
@@ -10,6 +10,15 @@ import org.springframework.context.annotation.Configuration;
 @Configuration
 @ConfigurationProperties(prefix = "mybatis.mapper.reload")
 public class MybatisMapperXmlFileReloadProperties {
+
+    public MybatisMapperXmlFileReloadProperties(boolean enable, String mapperLocation) {
+        this.enable = enable;
+        this.mapperLocation = mapperLocation;
+    }
+
+    public MybatisMapperXmlFileReloadProperties() {
+    }
+
     /**
      * 是否开启
      */

--- a/src/main/java/com/github/wangji92/mybatis/reload/core/MybatisMapperXmlFileReloadService.java
+++ b/src/main/java/com/github/wangji92/mybatis/reload/core/MybatisMapperXmlFileReloadService.java
@@ -72,6 +72,12 @@ public class MybatisMapperXmlFileReloadService {
     }
 
 
+    /**
+     * 重新加载mapper接口  【这里可以使用arthas 进行调用远程增强】
+     * eg  ognl -x 3 '#springContext=@com.wangji92.arthas.plugin.demo.common.ApplicationContextProvider@context,#springContext.getBean("mybatisMapperXmlFileReloadService").reloadAllSqlSessionFactoryMapper("com.xxx.StudentMapper")' -c xxx
+     * @param namespace  same as mapper full class name
+     * @return
+     */
     public void reloadAllMapperClazz(String namespace) {
         if (CollectionUtils.isEmpty(sqlSessionFactoryList)) {
             return;

--- a/src/main/java/com/github/wangji92/mybatis/reload/core/MybatisMapperXmlFileWatchService.java
+++ b/src/main/java/com/github/wangji92/mybatis/reload/core/MybatisMapperXmlFileWatchService.java
@@ -107,7 +107,7 @@ public class MybatisMapperXmlFileWatchService implements DisposableBean {
                                     fullPath)) {
                                 return;
                             }
-                            boolean result = mybatisMapperXmlFileReloadService.reloadAllSqlSessionFactoryMapper(fullPath);
+                            boolean result = mybatisMapperXmlFileReloadService.reloadAllMapperXml(fullPath);
                             log.info("path={} reload count ={} result={}", path, reloadCount.incrementAndGet(), result);
                         }
                     })


### PR DESCRIPTION
1 补充无xml场景下reload mapper接口的逻辑。  
2 之前的老代码 无法从Configuration对象中干净的移除缓存的信息，尤其在使用了嵌套语句和 自动生成主键的情况下，老代码存在bug，所以做了一定的修复。  